### PR TITLE
Add operator>> to classes with operator<<, so we can use them as ERS issue attributes

### DIFF
--- a/include/dataformats/ComponentRequest.hpp
+++ b/include/dataformats/ComponentRequest.hpp
@@ -45,6 +45,20 @@ operator<<(std::ostream& o, ComponentRequest const& cr)
 {
   return o << cr.component << ", begin: " << cr.window_begin << ", end: " << cr.window_end;
 }
+
+/**
+ * @brief Read a ComponentRequest from a string stream
+ * @param is Input stream
+ * @param cr ComponentRequest to read
+ * @return Stream instance for continued streaming
+ */
+inline std::istream&
+operator>>(std::istream& is, ComponentRequest & cr)
+{
+  std::string tmp;
+  return is >> cr.component >> tmp >> tmp >> cr.window_begin >> tmp >> tmp >> cr.window_end;
+}
+
 } // namespace dataformats
 } // namespace dunedaq
 

--- a/include/dataformats/GeoID.hpp
+++ b/include/dataformats/GeoID.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <limits>
 #include <ostream>
+#include <istream>
 #include <tuple>
 
 namespace dunedaq {
@@ -85,6 +86,20 @@ operator<<(std::ostream& o, GeoID const& id)
 {
   return o << "APA: " << id.apa_number << ", link: " << id.link_number;
 }
+
+/**
+ * @brief Read a GeoID from a string stream
+ * @param is Stream to read from
+ * @param id GeoID to fill
+ * @return Stream instance for further streaming
+ */
+inline std::istream&
+operator>>(std::istream& is, GeoID& id)
+{
+  std::string tmp;
+  return is >> tmp >> id.apa_number >> tmp >> tmp >> id.link_number;
+}
+
 } // namespace dataformats
 } // namespace dunedaq
 

--- a/include/dataformats/TriggerRecordHeaderData.hpp
+++ b/include/dataformats/TriggerRecordHeaderData.hpp
@@ -154,6 +154,26 @@ operator<<(std::ostream& o, TriggerRecordHeaderData const& hdr)
            << "num_requested_components: " << hdr.num_requested_components;
 }
 
+/**
+ * @brief Read a TriggerRecordHeaderData instance from a string stream
+ * @param is Stream to read from
+ * @param hdr TriggerRecordHeaderData toread
+ * @return Stream instance for continued streaming
+ */
+inline std::istream&
+operator>>(std::istream& o, TriggerRecordHeaderData& hdr)
+{
+  std::string tmp;
+  return o >> tmp >> std::hex >> hdr.trigger_record_header_marker >> std::dec >> tmp
+           >> tmp >> hdr.version           >> tmp
+           >> tmp >> hdr.trigger_number    >> tmp
+           >> tmp >> hdr.run_number        >> tmp
+           >> tmp >> hdr.trigger_timestamp >> tmp
+           >> tmp >> hdr.trigger_type      >> tmp
+           >> tmp >> hdr.error_bits        >> tmp
+           >> tmp >> hdr.num_requested_components;
+}
+
 } // namespace dataformats
 } // namespace dunedaq
 

--- a/unittest/ComponentRequest_test.cxx
+++ b/unittest/ComponentRequest_test.cxx
@@ -48,6 +48,13 @@ BOOST_AUTO_TEST_CASE(StreamOperator)
   BOOST_REQUIRE(pos != std::string::npos);
   pos = output.find("begin: 3,");
   BOOST_REQUIRE(pos != std::string::npos);
+
+  std::istringstream istr(output);
+  ComponentRequest component_from_stream;
+  istr >> component_from_stream;
+  BOOST_REQUIRE_EQUAL(component_from_stream.component, component.component);
+  BOOST_REQUIRE_EQUAL(component_from_stream.window_begin, component.window_begin);
+  BOOST_REQUIRE_EQUAL(component_from_stream.window_end, component.window_end);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/GeoID_test.cxx
+++ b/unittest/GeoID_test.cxx
@@ -7,6 +7,7 @@
  */
 
 #include "dataformats/GeoID.hpp"
+#include <sstream>
 
 /**
  * @brief Name of this test module
@@ -40,6 +41,11 @@ BOOST_AUTO_TEST_CASE(StreamOperator)
   BOOST_REQUIRE(!output.empty());
   auto pos = output.find("APA: 1,");
   BOOST_REQUIRE(pos != std::string::npos);
+
+  std::istringstream istr(output);
+  GeoID test2;
+  istr >> test2;
+  BOOST_REQUIRE_EQUAL(test2, test);
 }
 
 /**

--- a/unittest/TriggerRecordHeader_test.cxx
+++ b/unittest/TriggerRecordHeader_test.cxx
@@ -7,6 +7,8 @@
  */
 
 #include "dataformats/TriggerRecordHeader.hpp"
+#include "dataformats/TriggerRecordHeaderData.hpp"
+#include <sstream>
 
 /**
  * @brief Name of this test module
@@ -154,6 +156,17 @@ BOOST_AUTO_TEST_CASE(HeaderFields)
   header->set_run_number(10);
   BOOST_REQUIRE(header_ptr->run_number != header_data.run_number);
   BOOST_REQUIRE_EQUAL(header_ptr->run_number, 10);
+
+  std::ostringstream oss;
+  oss << header_data;
+  std::istringstream iss(oss.str());
+  TriggerRecordHeaderData trhd;
+  iss >> trhd;
+  BOOST_REQUIRE_EQUAL(trhd.run_number, header_data.run_number);
+  BOOST_REQUIRE_EQUAL(trhd.trigger_number, header_data.trigger_number);
+  BOOST_REQUIRE_EQUAL(trhd.trigger_timestamp, header_data.trigger_timestamp);
+  BOOST_REQUIRE_EQUAL(trhd.trigger_type, header_data.trigger_type);
+  BOOST_REQUIRE_EQUAL(trhd.num_requested_components, header_data.num_requested_components);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds an `operator>>` implementation to all of the classes that have an `operator<<` implementation. This is needed in order to be able to use the classes as ERS issue attributes.