### PR TITLE
Roland sipos/pdsframe

### DIFF
--- a/include/dataformats/pds/PDSFrame.hpp
+++ b/include/dataformats/pds/PDSFrame.hpp
@@ -13,7 +13,7 @@ namespace dunedaq::dataformats {
 /**
  *  @brief Class for accessing raw PDS frames, as produced by the DAPHNE boards
  *
- *  The canonical definition of the WIB format is given in EDMS document 2088726:
+ *  The canonical definition of the PDS DAPHNE format is given in EDMS document 2088726:
  *  https://edms.cern.ch/document/2088726/3
  */
 class PDSFrame


### PR DESCRIPTION
Hello. This PR contains the preliminary version of the PDS frame, based on:
https://edms.cern.ch/document/2088726/3

As you see, the structure is extremely similar to the WIB/WIB2 formats, the adc access functions are the same, only the header and trailer bitfields are changed to PD.