### PR TITLE
Add fragment overlay class for a list of TriggerPrimitives

### DIFF
--- a/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
+++ b/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
@@ -38,15 +38,16 @@ struct TriggerPrimitivesFragment
 
   uint32_t magic = s_tpf_header_magic;
   uint32_t version = s_tpf_version; // NOLINT(build/unsigned)
-  uint64_t num_trigger_primitives;    // NOLINT(build/unsigned)
+  uint64_t num_trigger_primitives;  // NOLINT(build/unsigned)
 
   const TriggerPrimitive& at(size_t i) const
   {
-    if(i>=num_trigger_primitives){
+    if (i >= num_trigger_primitives) {
       throw std::out_of_range("Primitive index out of range");
     }
-    const void* start_of_primitives=this+1;
-    return *reinterpret_cast<const TriggerPrimitive*>(static_cast<const char*>(start_of_primitives) + i*sizeof(TriggerPrimitive));
+    const void* start_of_primitives = this + 1;
+    return *reinterpret_cast<const TriggerPrimitive*>(static_cast<const char*>(start_of_primitives) +
+                                                      i * sizeof(TriggerPrimitive));
   }
 
   TriggerPrimitive& at(size_t i)
@@ -57,7 +58,6 @@ struct TriggerPrimitivesFragment
     // "Effective C++"
     return const_cast<TriggerPrimitive&>(static_cast<const TriggerPrimitivesFragment&>(*this).at(i));
   }
-
 };
 
 } // namespace dataformats

--- a/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
+++ b/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
@@ -1,0 +1,44 @@
+#ifndef DATAFORMATS_INCLUDE_DATAFORMATS_TRIGGER_TRIGGERPRIMITIVESFRAGMENT_HPP_
+#define DATAFORMATS_INCLUDE_DATAFORMATS_TRIGGER_TRIGGERPRIMITIVESFRAGMENT_HPP_
+
+#include <cstdint>
+
+namespace dunedaq {
+
+namespace dataformats {
+
+struct TriggerPrimitivesFragment
+{
+  static constexpr uint32_t s_tpf_header_magic = 0xcafecafe; // NOLINT(build/unsigned)
+  static constexpr uint32_t s_tpf_version = 1;               // NOLINT(build/unsigned)
+
+  struct TriggerPrimitive
+  {
+    uint64_t time_start;          // NOLINT(build/unsigned)
+    uint64_t time_peak;           // NOLINT(build/unsigned)
+    uint64_t time_over_threshold; // NOLINT(build/unsigned)
+    uint32_t channel;             // NOLINT(build/unsigned)
+    uint32_t adc_integral;        // NOLINT(build/unsigned)
+    uint16_t adc_peak;            // NOLINT(build/unsigned)
+    uint16_t detid;               // NOLINT(build/unsigned)
+    uint32_t type;                // NOLINT(build/unsigned)
+    uint32_t algorithm;           // NOLINT(build/unsigned)
+    uint16_t version;             // NOLINT(build/unsigned)
+    uint16_t flag;                // NOLINT(build/unsigned)
+  };
+
+  uint32_t magic = s_tpf_header_magic;
+  uint32_t version = s_tpf_version; // NOLINT(build/unsigned)
+  uint64_t n_trigger_primitives;    // NOLINT(build/unsigned)
+
+  // This is a "flexible array member", which is strictly not part of
+  // the C++ standard, although it happens to work. If we don't want
+  // to use this, we can manually calculate offsets into the structure
+  // to get pointers to the individual TriggerPrimitive structures
+  TriggerPrimitive primitives[];
+};
+
+} // namespace dataformats
+} // namespace dunedaq
+
+#endif // DATAFORMATS_INCLUDE_DATAFORMATS_TRIGGER_TRIGGERPRIMITIVEFRAGMENT_HPP_

--- a/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
+++ b/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
@@ -31,11 +31,11 @@ struct TriggerPrimitivesFragment
 
   uint32_t magic = s_tpf_header_magic;
   uint32_t version = s_tpf_version; // NOLINT(build/unsigned)
-  uint64_t n_trigger_primitives;    // NOLINT(build/unsigned)
+  uint64_t num_trigger_primitives;    // NOLINT(build/unsigned)
 
   const TriggerPrimitive& at(size_t i) const
   {
-    if(i>=n_trigger_primitives){
+    if(i>=num_trigger_primitives){
       throw std::out_of_range("Primitive index out of range");
     }
     const void* start_of_primitives=this+1;

--- a/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
+++ b/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
@@ -1,3 +1,10 @@
+/**
+ * @file TriggerPrimitivesFragment.hpp Fragment format for trigger primitives
+ *
+ * This is part of the DUNE DAQ, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
 #ifndef DATAFORMATS_INCLUDE_DATAFORMATS_TRIGGER_TRIGGERPRIMITIVESFRAGMENT_HPP_
 #define DATAFORMATS_INCLUDE_DATAFORMATS_TRIGGER_TRIGGERPRIMITIVESFRAGMENT_HPP_
 

--- a/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
+++ b/include/dataformats/trigger/TriggerPrimitivesFragment.hpp
@@ -36,9 +36,9 @@ struct TriggerPrimitivesFragment
     uint16_t flag;                // NOLINT(build/unsigned)
   };
 
-  uint32_t magic = s_tpf_header_magic;
-  uint32_t version = s_tpf_version; // NOLINT(build/unsigned)
-  uint64_t num_trigger_primitives;  // NOLINT(build/unsigned)
+  uint32_t magic = s_tpf_header_magic; // NOLINT(build/unsigned)
+  uint32_t version = s_tpf_version;    // NOLINT(build/unsigned)
+  uint64_t num_trigger_primitives;     // NOLINT(build/unsigned)
 
   const TriggerPrimitive& at(size_t i) const
   {
@@ -46,8 +46,8 @@ struct TriggerPrimitivesFragment
       throw std::out_of_range("Primitive index out of range");
     }
     const void* start_of_primitives = this + 1;
-    return *reinterpret_cast<const TriggerPrimitive*>(static_cast<const char*>(start_of_primitives) +
-                                                      i * sizeof(TriggerPrimitive));
+    return *reinterpret_cast<const TriggerPrimitive*>( // NOLINT
+      static_cast<const char*>(start_of_primitives) + i * sizeof(TriggerPrimitive));
   }
 
   TriggerPrimitive& at(size_t i)
@@ -63,4 +63,4 @@ struct TriggerPrimitivesFragment
 } // namespace dataformats
 } // namespace dunedaq
 
-#endif // DATAFORMATS_INCLUDE_DATAFORMATS_TRIGGER_TRIGGERPRIMITIVEFRAGMENT_HPP_
+#endif // DATAFORMATS_INCLUDE_DATAFORMATS_TRIGGER_TRIGGERPRIMITIVESFRAGMENT_HPP_


### PR DESCRIPTION
In order to save lists of trigger primitives in trigger records, we
need a way to pack them into fragments. This commit provides the
overlay class representing an ad hoc serialization of a list of
trigger primitive objects. (It was decided not to use the
functionality of the serialization package to achieve this, as it
would make fragments containing DS objects look different to fragments
containing data from hardware, and would require offline to depend on
a library to read the MsgPack or JSON format used by the serialization
package).

This commit is just the overlay: code to create Fragment objects and
fill them with TP data is in trigger/FragmentMakers.hpp, along with
code to read back the TPs out of Fragments.

We will eventually need similar overlays for TriggerActivity and TriggerCandidate. If the approach in this PR is approved, I'll work on doing the same for these other classes.